### PR TITLE
[Tweaks] Removing required aws profile info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Amazon S3 CSI Driver Provisioning using Terraform
+
 ### This repo consists of terraform files that provisions S3 Driver in EKS cluster
 
 Amazon S3 Driver is a software component that acts like a translator or bridge between the eks and S3. This driver is a static provisioning storage system, it mean mount pre-existing buckets to the pods as persisitant volumes.
-The driver acts like an interface between eks and s3. 
+The driver acts like an interface between eks and s3.
 
-This repo. creates an IAM Role with assume role policy for OIDC provider along with S3 Bucket Policy. 
+This repo. creates an IAM Role with assume role policy for OIDC provider along with S3 Bucket Policy.
 
 ## How to use this module to install S3 CSI Driver
 
@@ -15,25 +16,26 @@ Create an OIDC provider for you cluster:
 ```sh
 eksctl utils associate-iam-oidc-provider --cluster $cluster_name --approve
 ```
+
 Replace cluster_name with your eks cluster name.
 
-Then add below piece of code in your terraform configuration, and place your inputs such as  `region`, `aws_profile`,  `bucket_name`, `cluster_name` and give name for `Iam Role`. Here this role assigns with policy having s3 bucket permissions and role has assumeRole policy with eks cluster.
+Then add below piece of code in your terraform configuration, and place your inputs such as  `region`,  `bucket_name`, `cluster_name` and give name for `Iam Role`. Here this role assigns with policy having s3 bucket permissions and role has assumeRole policy with eks cluster.
 
 ```sh
 module "s3-csi-driver" {
   source           = "krupakar0307/s3-csi-driver/aws"
   version          = "0.0.2"
   aws_region       = "region"
-  aws_profile      = "profile_name"
   bucket_name      = "bucket_name"
   iam_role_name    = "role_name"
   eks_cluster      = "cluster_name"
 }
 ```
+
 Apply `terraform init`, `terraform plan` and followed by `terraform apply`.
 
-After applying, you will notice pods coming up in `kube-system` namespace. 
-Then create your pv.yaml, pvc.yaml and pod.yaml files. mount s3 bucket in your pv configuration. 
+After applying, you will notice pods coming up in `kube-system` namespace.
+Then create your pv.yaml, pvc.yaml and pod.yaml files. mount s3 bucket in your pv configuration.
 
 you can take a reference of how to mount s3 bucket with in pod configuration from this [static-provisioning yaml](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/main/examples/kubernetes/static_provisioning/static_provisioning.yaml)
 
@@ -42,6 +44,5 @@ Finally you can see the files which are available in your s3 bucket inside your 
 In the screenshot below, I used the mount S3 bucket in the data folder, and you can see two files available in the bucket, which is reflected in the pod's directory.
 
 ![Screenshot](screenshot.png)
-
 
 Thanks!

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_policy" "s3_eks_policy" {
   name        = "${var.bucket_name}-s3-mount-policy"
   description = "IAM policy for S3 bucket access"
+  tags        = var.tags
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -28,6 +29,7 @@ resource "aws_iam_policy" "s3_eks_policy" {
 
 resource "aws_iam_role" "s3_eks_role" {
   name = "${var.iam_role_name}-s3-mount-role"
+  tags = var.tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",

--- a/main.tf
+++ b/main.tf
@@ -4,4 +4,5 @@ resource "aws_eks_addon" "eks_s3_csi" {
   addon_version               = data.aws_eks_addon_version.s3_csi_driver.version
   resolve_conflicts_on_create = "OVERWRITE"
   service_account_role_arn    = aws_iam_role.s3_eks_role.arn
+  tags                        = var.tags
 }

--- a/provider.tf
+++ b/provider.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-provider "aws" {
-  region  = var.aws_region
-  profile = var.aws_profile
-}

--- a/vars.tf
+++ b/vars.tf
@@ -1,7 +1,3 @@
-variable "aws_profile" {
-  description = "provide your environment profile"
-  type        = string
-}
 variable "aws_region" {
   description = "provide your aws region"
   type        = string

--- a/vars.tf
+++ b/vars.tf
@@ -15,3 +15,9 @@ variable "eks_cluster" {
   type        = string
   description = "provide eks cluster name to provision s3 csi with your cluster"
 }
+
+
+variable "tags" {
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
- Not sure if this  really makes sense, thought it might be helpful.
- Removing the variable `aws_profile` as that could be env managed
- Adding variable `tags`  for tagging the resources for brevity